### PR TITLE
Add a fmod function that can give the modulo of two real numbers

### DIFF
--- a/src/BCMathExtended/BC.php
+++ b/src/BCMathExtended/BC.php
@@ -296,7 +296,7 @@ class BC
             $leftOperand,
             self::mul(
                 $modulus,
-                self::floor(self::div($leftOperand, $modulus)),
+                self::floor(self::div($leftOperand, $modulus, $scale)),
                 $scale
             ),
             $scale

--- a/src/BCMathExtended/BC.php
+++ b/src/BCMathExtended/BC.php
@@ -280,6 +280,31 @@ class BC
 
     /**
      * @param string $leftOperand
+     * @param string $modulus
+     * @param int $scale
+     * @return string
+     */
+    public static function fmod($leftOperand, $modulus, $scale = null)
+    {
+        // From PHP 7.2 on, bcmod can handle real numbers
+        if (version_compare(PHP_VERSION, '7.2.0') >= 0) {
+            return bcmod($leftOperand, $modulus);
+        }
+
+        // mod(a, b) = a - b * floor(a/b)
+        return self::sub(
+            $leftOperand,
+            self::mul(
+                $modulus,
+                self::floor(self::div($leftOperand, $modulus)),
+                $scale
+            ),
+            $scale
+        );
+    }
+
+    /**
+     * @param string $leftOperand
      * @param string $rightOperand
      * @param int $scale
      * @return string

--- a/tests/Unit/BCTest.php
+++ b/tests/Unit/BCTest.php
@@ -170,7 +170,7 @@ class BCTest extends \PHPUnit_Framework_TestCase
         self::assertSame(3, BC::max(1, 2, 3));
         self::assertSame(6, BC::max(6, 3, 2));
         self::assertSame(999, BC::max(100, 999, 5));
-      
+
         self::assertSame(677, BC::max(array(3, 5, 677)));
         self::assertSame(-3, BC::max(array(-3, -5, -677)));
 
@@ -320,6 +320,17 @@ class BCTest extends \PHPUnit_Framework_TestCase
         self::assertSame('1', BC::mod('11', '2'));
         self::assertSame('-1', BC::mod('-1', '5'));
         self::assertSame('1459434331351930289678', BC::mod('8728932001983192837219398127471', '1928372132132819737213'));
+    }
+
+    /**
+     * @test
+     */
+    public function shouldFmod()
+    {
+        self::assertSame('0.8', BC::fmod('10', '9.2', 1));
+        self::assertSame('0.0', BC::fmod('20', '4.0', 1));
+        self::assertSame('0.0', BC::fmod('10.5', '3.5', 1));
+        self::assertSame('0.3', BC::fmod('10.2', '3.3', 1));
     }
 
     /**


### PR DESCRIPTION
See [this thread on Stackoverflow](https://stackoverflow.com/questions/46669629/getting-the-modulo-of-two-real-numbers-with-bcmath):

Before PHP 7.2, bcmod does not handle real numbers well. There is no alternative function to PHP's native [fmod](http://php.net/manual/en/function.fmod.php) in BC Math.

I added a function called ``BC::fmod`` that can give the remainder after "divving" two real numbers. In theory this function can replace the ''mod''-function, especially since it mimics the behaviour of bcmod from PHP 7.2. However creating a separate function minimises the risk of introducing problems with users that might falsely rely on the current behaviour.