### PR TITLE
Add hexdec() and dechex() functions

### DIFF
--- a/src/BCMathExtended/BC.php
+++ b/src/BCMathExtended/BC.php
@@ -568,4 +568,34 @@ class BC
 
         return $return;
     }
+
+    /**
+     * @param string $hex
+     * @return string
+     */
+    public static function hexdec($hex) {
+        $remainingDigits = substr($hex, 0, -1);
+        $lastDigitToDecimal = \hexdec(substr($hex, -1));
+
+        if (strlen($remainingDigits) === 0) {
+            return $lastDigitToDecimal;
+        }
+
+        return self::add(self::mul(16, self::hexdec($remainingDigits)), $lastDigitToDecimal, 0);
+    }
+
+    /**
+     * @param int $decimal
+     * @return string
+     */
+    public static function dechex($decimal) {
+        $quotient = self::div($decimal, 16, 0);
+        $remainderToHex = \dechex(self::mod($decimal, 16));
+
+        if (self::comp($quotient, 0) === 0) {
+            return $remainderToHex;
+        }
+
+        return self::dechex($quotient) . $remainderToHex;
+    }
 }

--- a/tests/Unit/BCTest.php
+++ b/tests/Unit/BCTest.php
@@ -1005,6 +1005,55 @@ class BCTest extends TestCase
         self::assertSame('3.07', BC::sqrt('9.444'));
     }
 
+    public function hexdecProvider()
+    {
+        return [
+            ['123', '7b'],
+            ['1234567890', '499602d2'],
+            ['12345678901234567890', 'ab54a98ceb1f0ad2'],
+            ['123456789012345678901234567890', '18ee90ff6c373e0ee4e3f0ad2'],
+            ['1234567890123456789012345678901234567890', '3a0c92075c0dbf3b8acbc5f96ce3f0ad2'],
+        ];
+    }
+
+    /**
+     * @test
+     * @param string $expected
+     * @param string $operand
+     * @dataProvider hexdecProvider
+     */
+    public function shouldHexdec($expected, $operand)
+    {
+        $number = BC::hexdec($operand);
+        self::assertInternalType('string', $number);
+        self::assertSame($expected, $number);
+    }
+
+    public function dechexProvider()
+    {
+        return [
+            ['7b', '123'],
+            ['ffffffff', '4294967295'],
+            ['200000000', '8589934592'],
+            ['7fffffffffffffff', '9223372036854775807'],
+            ['10000000000000000', '18446744073709551616'],
+            ['18ee90ff6c373e0ee4e3f0ad2', '123456789012345678901234567890'],
+        ];
+    }
+
+    /**
+     * @test
+     * @param string $expected
+     * @param string $operand
+     * @dataProvider dechexProvider
+     */
+    public function shouldDechex($expected, $operand)
+    {
+        $number = BC::dechex($operand);
+        self::assertInternalType('string', $number);
+        self::assertSame($expected, $number);
+    }
+
     protected function setUp()
     {
         BC::setScale(2);


### PR DESCRIPTION
**Overview**:
Introduce two new functions (`hexdec()` and `dechex()`) for converting large numbers from hexadecimal to decimal and vice versa.

**Motivation:**

1. The official PHP documentation says that the largest number that can be converted from decimal to hexadecimal using PHP's built-in `dechex()` function is ` PHP_INT_MAX * 2 + 1`, but generally going over `PHP_INT_MAX` starts producing strange and unreliable results. Consider the following example:

    ```php
    echo PHP_INT_MAX;
    // output is: 9223372036854775807

    echo dechex(PHP_INT_MAX);
    // output is: 7fffffffffffffff

    echo dechex(PHP_INT_MAX * 2 - 3000);
    // decimal: 18446744073709548614
    // casts to: 1.844674407371E+19
    // output: fffffffffffff800
    // corresponds to: 18446744073709549568 in decimal (off by 451386)

    echo dechex(PHP_INT_MAX * 2 - 2000);
    // decimal: 18446744073709549614
    // also casts to: 1.844674407371E+19
    // also outputs: fffffffffffff800
    // corresponds to 18446744073709549568 in decimal (off by 450386)

    echo dechex(PHP_INT_MAX * 2 - 1000);
    // supposedly also casts to: 1.844674407371E+19
    // but output is: 0

    echo dechex(PHP_INT_MAX * 2);
    // output is: 0
    ```
2. PHP's built-in `hexdec()` function can convert numbers that are too large to fit into the platform's integer type. However, larger values are returned as float, and in that case there is a loss in precision. Consider this example:
    
    ```php
    $num = '18ee90ff6c373e0ee4e3f0ad2';

    echo BC::hexdec($num);
    // output is: "123456789012345678901234567890"

    echo BC::convertScientificNotationToString(\hexdec($num));
    // output is: "123456789012350000000000000000"
    ```


