### PR TITLE
Explicitly list PHP 8 as a tested version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   ],
   "type": "library",
   "require": {
-    "php": ">=7.1",
+    "php": "^7.1|^8.0",
     "ext-bcmath": "*"
   },
   "require-dev": {


### PR DESCRIPTION
Hello there,

I was trying to assert whether or not this library has been "checked up" against PHP 8. I first looked in Composer and saw ">=7.1", which isn't a clear sign it was. Then I looked at the last tag (6 months old already), and saw nothing in the tag's description referring to PHP 8. So finally I looked at the PRs history and found https://github.com/krowinski/bcmath-extended/pull/37, which seems to be exactly what I was looking for.

So I thought I'd contribute by adding an explicit version support in composer.json. Feel free to merge or close, whether it makes sense to you (or not).