### PR TITLE
Allow null as input for backward compatibility with PHP's BCMath functions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 /vendor
 composer.lock
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,6 @@ install:
   travis_retry composer install --no-interaction --prefer-source
 
 script: vendor/bin/phpunit
+
+after_script:
+  - vendor/bin/phpstan

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     "ext-bcmath": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.5|^8.0|^9.0"
+    "phpunit/phpunit": "^7.5|^8.0|^9.0",
+    "phpstan/phpstan": "^0.12.88"
   },
   "license": "MIT",
   "authors": [

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+    level: max
+    checkMissingIterableValueType: false
+    paths:
+        - src
+        - tests

--- a/src/BCMathExtended/BC.php
+++ b/src/BCMathExtended/BC.php
@@ -22,6 +22,9 @@ class BC
     protected const BIT_OPERATOR_OR = 'or';
     protected const BIT_OPERATOR_XOR = 'xor';
 
+    /**
+     * @var bool
+     */
     protected static $trimTrailingZeroes = true;
 
     public static function rand(string $min, string $max): string
@@ -35,8 +38,12 @@ class BC
         return static::add($min, static::mul($difference, $randPercent, 8), 0);
     }
 
-    public static function convertScientificNotationToString(string $number): string
+    public static function convertScientificNotationToString(?string $number): string
     {
+        if (null === $number) {
+            return '0';
+        }
+
         // check if number is in scientific notation, first use stripos as is faster then preg_match
         if (false !== stripos($number, 'E') && preg_match('/(-?(\d+\.)?\d+)E([+-]?)(\d+)/i', $number, $regs)) {
             // calculate final scale of number
@@ -53,9 +60,9 @@ class BC
         return static::parseNumber($number);
     }
 
-    public static function getDecimalsLength(string $number): int
+    public static function getDecimalsLength(?string $number): int
     {
-        if (static::isFloat($number)) {
+        if (null !== $number && static::isFloat($number)) {
             return strcspn(strrev($number), '.');
         }
 
@@ -67,7 +74,7 @@ class BC
         return false !== strpos($number, '.');
     }
 
-    public static function pow(string $base, string $exponent, ?int $scale = null): string
+    public static function pow(?string $base, ?string $exponent, ?int $scale = null): string
     {
         $base = static::convertScientificNotationToString($base);
         $exponent = static::convertScientificNotationToString($exponent);
@@ -112,7 +119,7 @@ class BC
         return strlen(substr($sqrt, strpos($sqrt, '.') + 1));
     }
 
-    public static function sqrt(string $number, ?int $scale = null): string
+    public static function sqrt(?string $number, ?int $scale = null): string
     {
         $number = static::convertScientificNotationToString($number);
 
@@ -125,8 +132,12 @@ class BC
         return static::formatTrailingZeroes($r, $scale);
     }
 
-    protected static function formatTrailingZeroes(string $number, ?int $scale = null): string
+    protected static function formatTrailingZeroes(?string $number, ?int $scale = null): string
     {
+        if (null === $number) {
+            return '0';
+        }
+
         if (self::$trimTrailingZeroes) {
             return static::trimTrailingZeroes($number);
         }
@@ -140,8 +151,12 @@ class BC
         return self::addTrailingZeroes($number, $scale);
     }
 
-    protected static function trimTrailingZeroes(string $number): string
+    protected static function trimTrailingZeroes(?string $number): string
     {
+        if (null === $number) {
+            return '0';
+        }
+
         if (static::isFloat($number)) {
             $number = rtrim($number, '0');
         }
@@ -169,7 +184,7 @@ class BC
 
     protected static function parseNumber(string $number): string
     {
-        $number = str_replace('+', '', filter_var($number, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION));
+        $number = str_replace('+', '', (string) filter_var($number, FILTER_SANITIZE_NUMBER_FLOAT, FILTER_FLAG_ALLOW_FRACTION));
         if ('-0' === $number || !is_numeric($number)) {
             return '0';
         }
@@ -177,7 +192,7 @@ class BC
         return $number;
     }
 
-    public static function add(string $leftOperand, string $rightOperand, ?int $scale = null): string
+    public static function add(?string $leftOperand, ?string $rightOperand, ?int $scale = null): string
     {
         $leftOperand = static::convertScientificNotationToString($leftOperand);
         $rightOperand = static::convertScientificNotationToString($rightOperand);
@@ -191,7 +206,7 @@ class BC
         return static::formatTrailingZeroes($r, $scale);
     }
 
-    public static function exp(string $number): string
+    public static function exp(?string $number): string
     {
         $scale = static::DEFAULT_SCALE;
         $result = '1';
@@ -202,7 +217,7 @@ class BC
         return $result;
     }
 
-    public static function mul(string $leftOperand, string $rightOperand, ?int $scale = null): string
+    public static function mul(?string $leftOperand, ?string $rightOperand, ?int $scale = null): string
     {
         $leftOperand = static::convertScientificNotationToString($leftOperand);
         $rightOperand = static::convertScientificNotationToString($rightOperand);
@@ -216,7 +231,7 @@ class BC
         return static::formatTrailingZeroes($r, $scale);
     }
 
-    public static function div(string $dividend, string $divisor, ?int $scale = null): string
+    public static function div(?string $dividend, ?string $divisor, ?int $scale = null): string
     {
         $dividend = static::convertScientificNotationToString($dividend);
         $divisor = static::convertScientificNotationToString($divisor);
@@ -238,7 +253,7 @@ class BC
         return static::formatTrailingZeroes($r, $scale);
     }
 
-    public static function log(string $number): string
+    public static function log(?string $number): string
     {
         $number = static::convertScientificNotationToString($number);
         if ($number === '0') {
@@ -267,7 +282,7 @@ class BC
         return static::add($res, $m, $scale);
     }
 
-    public static function comp(string $leftOperand, string $rightOperand, ?int $scale = null): int
+    public static function comp(?string $leftOperand, ?string $rightOperand, ?int $scale = null): int
     {
         $leftOperand = static::convertScientificNotationToString($leftOperand);
         $rightOperand = static::convertScientificNotationToString($rightOperand);
@@ -283,7 +298,7 @@ class BC
         );
     }
 
-    public static function sub(string $leftOperand, string $rightOperand, ?int $scale = null): string
+    public static function sub(?string $leftOperand, ?string $rightOperand, ?int $scale = null): string
     {
         $leftOperand = static::convertScientificNotationToString($leftOperand);
         $rightOperand = static::convertScientificNotationToString($rightOperand);
@@ -302,6 +317,9 @@ class BC
         self::$trimTrailingZeroes = $flag;
     }
 
+    /**
+     * @param array<int, string|float|int|null>|string|float|int|null ...$values
+     */
     public static function max(...$values): ?string
     {
         $max = null;
@@ -326,6 +344,9 @@ class BC
         return $values;
     }
 
+    /**
+     * @param array<int, string|float|int|null>|string|float|int|null ...$values
+     */
     public static function min(...$values): ?string
     {
         $min = null;
@@ -342,9 +363,9 @@ class BC
     }
 
     public static function powMod(
-        string $base,
-        string $exponent,
-        string $modulus,
+        ?string $base,
+        ?string $exponent,
+        ?string $modulus,
         ?int $scale = null
     ): string {
         $base = static::convertScientificNotationToString($base);
@@ -357,6 +378,7 @@ class BC
         if ('0' === static::trimTrailingZeroes($modulus)) {
             throw new InvalidArgumentException('Modulus can\'t be zero');
         }
+        /** @var string $modulus */
 
         // bcpowmod don't support floats
         if (
@@ -370,9 +392,10 @@ class BC
         } else {
             $r = bcpowmod($base, $exponent, $modulus, $scale);
         }
+        /** @var string|null|false $r */
 
-        if (null === $r) {
-            throw new UnexpectedValueException('bcpowmod should not return null!');
+        if (null === $r || false === $r) {
+            throw new UnexpectedValueException('bcpowmod should not return null|false!');
         }
 
         return static::formatTrailingZeroes($r, $scale);
@@ -383,7 +406,7 @@ class BC
         return 0 === strncmp('-', $number, 1);
     }
 
-    public static function mod(string $dividend, string $divisor, ?int $scale = null): string
+    public static function mod(?string $dividend, ?string $divisor, ?int $scale = null): string
     {
         $dividend = static::convertScientificNotationToString($dividend);
 
@@ -399,7 +422,7 @@ class BC
         );
     }
 
-    public static function floor(string $number): string
+    public static function floor(?string $number): string
     {
         $number = static::trimTrailingZeroes(static::convertScientificNotationToString($number));
         if (static::isFloat($number)) {
@@ -413,7 +436,7 @@ class BC
         return static::parseNumber($number);
     }
 
-    public static function fact(string $number): string
+    public static function fact(?string $number): string
     {
         $number = static::convertScientificNotationToString($number);
 
@@ -432,9 +455,10 @@ class BC
         return $return;
     }
 
-    public static function hexdec(string $hex): string
+    public static function hexdec(?string $hex): string
     {
-        $remainingDigits = substr($hex, 0, -1);
+        $hex = (string) $hex;
+        $remainingDigits = (string) substr($hex, 0, -1);
         $lastDigitToDecimal = (string)hexdec(substr($hex, -1));
 
         if ('' === $remainingDigits) {
@@ -444,7 +468,7 @@ class BC
         return static::add(static::mul('16', static::hexdec($remainingDigits)), $lastDigitToDecimal, 0);
     }
 
-    public static function dechex(string $decimal): string
+    public static function dechex(?string $decimal): string
     {
         $quotient = static::div($decimal, '16', 0);
         $remainderToHex = dechex((int)static::mod($decimal, '16'));
@@ -457,13 +481,13 @@ class BC
     }
 
     public static function bitAnd(
-        string $leftOperand,
-        string $rightOperand
+        ?string $leftOperand,
+        ?string $rightOperand
     ): string {
         return static::bitOperatorHelper($leftOperand, $rightOperand, static::BIT_OPERATOR_AND);
     }
 
-    protected static function bitOperatorHelper(string $leftOperand, string $rightOperand, string $operator): string
+    protected static function bitOperatorHelper(?string $leftOperand, ?string $rightOperand, string $operator): string
     {
         $leftOperand = static::convertScientificNotationToString($leftOperand);
         $rightOperand = static::convertScientificNotationToString($rightOperand);
@@ -551,12 +575,12 @@ class BC
         return $value;
     }
 
-    public static function setScale(int $scale): void
+    public static function setScale(?int $scale): void
     {
-        bcscale($scale);
+        bcscale((int) $scale);
     }
 
-    public static function abs(string $number): string
+    public static function abs(?string $number): string
     {
         $number = static::convertScientificNotationToString($number);
 
@@ -605,17 +629,17 @@ class BC
         );
     }
 
-    public static function bitOr(string $leftOperand, string $rightOperand): string
+    public static function bitOr(?string $leftOperand, ?string $rightOperand): string
     {
         return static::bitOperatorHelper($leftOperand, $rightOperand, static::BIT_OPERATOR_OR);
     }
 
-    public static function bitXor(string $leftOperand, string $rightOperand): string
+    public static function bitXor(?string $leftOperand, ?string $rightOperand): string
     {
         return static::bitOperatorHelper($leftOperand, $rightOperand, static::BIT_OPERATOR_XOR);
     }
 
-    public static function roundHalfEven(string $number, int $precision = 0): string
+    public static function roundHalfEven(?string $number, int $precision = 0): string
     {
         $number = static::convertScientificNotationToString($number);
         if (!static::isFloat($number)) {
@@ -643,7 +667,7 @@ class BC
         return static::roundDown($number, $precision);
     }
 
-    public static function round(string $number, int $precision = 0): string
+    public static function round(?string $number, int $precision = 0): string
     {
         $number = static::convertScientificNotationToString($number);
         if (static::isFloat($number)) {
@@ -657,7 +681,7 @@ class BC
         return static::parseNumber($number);
     }
 
-    public static function roundUp(string $number, int $precision = 0): string
+    public static function roundUp(?string $number, int $precision = 0): string
     {
         $number = static::convertScientificNotationToString($number);
         $multiply = static::pow('10', (string)abs($precision));
@@ -677,7 +701,7 @@ class BC
             );
     }
 
-    public static function ceil(string $number): string
+    public static function ceil(?string $number): string
     {
         $number = static::trimTrailingZeroes(static::convertScientificNotationToString($number));
         if (static::isFloat($number)) {
@@ -691,7 +715,7 @@ class BC
         return static::parseNumber($number);
     }
 
-    public static function roundDown(string $number, int $precision = 0): string
+    public static function roundDown(?string $number, int $precision = 0): string
     {
         $number = static::convertScientificNotationToString($number);
         $multiply = static::pow('10', (string)abs($precision));

--- a/tests/Unit/BCTest.php
+++ b/tests/Unit/BCTest.php
@@ -13,6 +13,7 @@ class BCTest extends TestCase
     public function scientificNotationProvider(): array
     {
         return [
+            ['0', null],
             ['0', '-0'],
             ['0', ''],
             ['666', '666'],
@@ -83,7 +84,7 @@ class BCTest extends TestCase
      * @test
      * @dataProvider scientificNotationProvider
      */
-    public function shouldConvertScientificNotationToString(string $expected, string $number): void
+    public function shouldConvertScientificNotationToString(string $expected, ?string $number): void
     {
         self::assertSame($expected, BC::convertScientificNotationToString($number));
     }
@@ -91,6 +92,7 @@ class BCTest extends TestCase
     public function ceilProvider(): array
     {
         return [
+            ['0', null],
             ['0', '-0'],
             ['-1', '-1'],
             ['-1', '-1.5'],
@@ -122,7 +124,7 @@ class BCTest extends TestCase
      * @test
      * @dataProvider ceilProvider
      */
-    public function shouldCeil(string $expected, string $number): void
+    public function shouldCeil(string $expected, ?string $number): void
     {
         self::assertSame($expected, BC::ceil($number));
     }
@@ -130,6 +132,7 @@ class BCTest extends TestCase
     public function floorProvider(): array
     {
         return [
+            ['0', null],
             ['0', '-0'],
             ['-1', '-0.5'],
             ['-1', '-1'],
@@ -168,7 +171,7 @@ class BCTest extends TestCase
      * @test
      * @dataProvider floorProvider
      */
-    public function shouldFloor(string $expected, string $number): void
+    public function shouldFloor(string $expected, ?string $number): void
     {
         self::assertSame($expected, BC::floor($number));
     }
@@ -176,6 +179,7 @@ class BCTest extends TestCase
     public function absProvider(): array
     {
         return [
+            ['0', null],
             ['1', '-1'],
             ['1.5', '-1.5'],
             ['1', '-1'],
@@ -201,7 +205,7 @@ class BCTest extends TestCase
      * @test
      * @dataProvider absProvider
      */
-    public function shouldAbs(string $expected, string $number): void
+    public function shouldAbs(string $expected, ?string $number): void
     {
         self::assertSame($expected, BC::abs($number));
     }
@@ -209,6 +213,7 @@ class BCTest extends TestCase
     public function roundProvider(): array
     {
         return [
+            ['0', null],
             ['3', '3.4'],
             ['4', '3.5'],
             ['4', '3.6'],
@@ -269,7 +274,7 @@ class BCTest extends TestCase
      * @test
      * @dataProvider roundProvider
      */
-    public function shouldRound(string $expected, string $number, int $precision = 0): void
+    public function shouldRound(string $expected, ?string $number, int $precision = 0): void
     {
         self::assertSame($expected, BC::round($number, $precision));
     }
@@ -277,6 +282,7 @@ class BCTest extends TestCase
     public function roundHalfEvenProvider(): array
     {
         return [
+            ['0', null],
             ['2', '1.8'],
             ['2', '1.5'],
             ['1', '1.2'],
@@ -308,7 +314,7 @@ class BCTest extends TestCase
      * @test
      * @dataProvider roundHalfEvenProvider
      */
-    public function shouldRoundHalfEven(string $expected, string $number, int $precision = 0): void
+    public function shouldRoundHalfEven(string $expected, ?string $number, int $precision = 0): void
     {
         self::assertSame($expected, BC::roundHalfEven($number, $precision));
     }
@@ -337,6 +343,7 @@ class BCTest extends TestCase
      */
     public function shouldMax(): void
     {
+        self::assertSame('0', BC::max(-1, null));
         self::assertSame('3', BC::max(1, 2, 3));
         self::assertSame('6', BC::max(6, 3, 2));
         self::assertSame('999', BC::max(100, 999, 5));
@@ -360,6 +367,7 @@ class BCTest extends TestCase
      */
     public function shouldMin(): void
     {
+        self::assertSame('0', BC::min('7.30', null));
         self::assertSame('7.20', BC::min('7.30', '7.20'));
         self::assertSame('3', BC::min([3, 5, 677]));
         self::assertSame('-677', BC::min([-3, -5, -677]));
@@ -380,6 +388,7 @@ class BCTest extends TestCase
     public function setScaleProvider(): array
     {
         return [
+            [null, '3', '1', '2'],
             [50, '3', '1', '2'],
             [0, '3', '1', '2'],
             [13, '3', '1', '2'],
@@ -399,6 +408,7 @@ class BCTest extends TestCase
     public function roundUpProvider(): array
     {
         return [
+            ['0', null],
             ['663', '662.79'],
             ['662.8', '662.79', 1],
             ['60', '54.1', -1],
@@ -423,7 +433,7 @@ class BCTest extends TestCase
      * @test
      * @dataProvider roundUpProvider
      */
-    public function shouldRoundUp(string $expected, string $number, int $precision = 0): void
+    public function shouldRoundUp(string $expected, ?string $number, int $precision = 0): void
     {
         self::assertSame($expected, BC::roundUp($number, $precision));
     }
@@ -431,6 +441,7 @@ class BCTest extends TestCase
     public function roundDownProvider(): array
     {
         return [
+            ['0', null],
             ['662', '662.79'],
             ['662.7', '662.79', 1],
             ['50', '54.1', -1],
@@ -454,9 +465,8 @@ class BCTest extends TestCase
     /**
      * @test
      * @dataProvider roundDownProvider
-     * @param int|float|string $number
      */
-    public function shouldRoundDown(string $expected, string $number, int $precision = 0): void
+    public function shouldRoundDown(string $expected, ?string $number, int $precision = 0): void
     {
         self::assertSame($expected, BC::roundDown($number, $precision));
     }
@@ -464,6 +474,9 @@ class BCTest extends TestCase
     public function addProvider(): array
     {
         return [
+            ['0', null, null],
+            ['15', null, '15'],
+            ['15', '15', null],
             ['3', '1', '2'],
             ['2', '1', '1'],
             ['15', '10', '5'],
@@ -480,7 +493,7 @@ class BCTest extends TestCase
      * @test
      * @dataProvider addProvider
      */
-    public function shouldAdd(string $expected, string $left, string $right, ?int $scale = 0): void
+    public function shouldAdd(string $expected, ?string $left, ?string $right, ?int $scale = 0): void
     {
         self::assertSame($expected, BC::add($left, $right, $scale));
     }
@@ -514,6 +527,9 @@ class BCTest extends TestCase
     public function subProvider(): array
     {
         return [
+            ['0', null, null],
+            ['-15', null, '15'],
+            ['15', '15', null],
             ['-1', '1', '2'],
             ['0', '1', '1'],
             ['5', '10', '5'],
@@ -528,7 +544,7 @@ class BCTest extends TestCase
      * @test
      * @dataProvider subProvider
      */
-    public function shouldSub(string $expected, string $left, string $right, ?int $scale = 0): void
+    public function shouldSub(string $expected, ?string $left, ?string $right, ?int $scale = 0): void
     {
         self::assertSame($expected, BC::sub($left, $right, $scale));
     }
@@ -536,6 +552,11 @@ class BCTest extends TestCase
     public function compProvider(): array
     {
         return [
+            [null, null, BC::COMPARE_EQUAL, 0],
+            [null, '0', BC::COMPARE_EQUAL, 0],
+            ['0', null, BC::COMPARE_EQUAL, 0],
+            [null, '1', BC::COMPARE_RIGHT_GRATER, 0],
+            ['1', null, BC::COMPARE_LEFT_GRATER, 0],
             ['-1', '5', BC::COMPARE_RIGHT_GRATER, 4],
             ['1928372132132819737213', '8728932001983192837219398127471', BC::COMPARE_RIGHT_GRATER, 1],
             ['1.00000000000000000001', '2', BC::COMPARE_RIGHT_GRATER, 1],
@@ -555,7 +576,7 @@ class BCTest extends TestCase
      * @test
      * @dataProvider compProvider
      */
-    public function shouldComp(string $left, string $right, int $expected, int $scale): void
+    public function shouldComp(?string $left, ?string $right, int $expected, int $scale): void
     {
         self::assertSame($expected, BC::comp($left, $right, $scale));
     }
@@ -583,6 +604,7 @@ class BCTest extends TestCase
     public function divProvider(): array
     {
         return [
+            ['0', null, '2', 0],
             ['0.5', '1', '2', 2],
             ['-0.2', '-1', '5', 4],
             ['4526580661.75', '8728932001983192837219398127471', '1928372132132819737213', 2],
@@ -594,19 +616,28 @@ class BCTest extends TestCase
      * @test
      * @dataProvider divProvider
      */
-    public function shouldDiv(string $expected, string $left, string $right, ?int $scale): void
+    public function shouldDiv(string $expected, ?string $left, ?string $right, ?int $scale): void
     {
         self::assertSame($expected, BC::div($left, $right, $scale));
     }
 
+    public function throwDivByZeroProvider(): array
+    {
+        return [
+            [null],
+            ['0'],
+        ];
+    }
+
     /**
      * @test
+     * @dataProvider throwDivByZeroProvider
      */
-    public function shouldThrowDivByZero(): void
+    public function divShouldThrowDivByZero(?string $divisor): void
     {
         $this->expectExceptionMessage('Division by zero');
         $this->expectException(InvalidArgumentException::class);
-        BC::div('1', '0');
+        BC::div('1', $divisor);
     }
 
     /**
@@ -625,6 +656,7 @@ class BCTest extends TestCase
     public function modProvider(): array
     {
         return [
+            ['0', null, '1', 0],
             ['1', '11', '2', 0],
             ['-1', '-1', '5', 0],
             ['1459434331351930289678', '8728932001983192837219398127471', '1928372132132819737213', 0],
@@ -643,15 +675,28 @@ class BCTest extends TestCase
      * @test
      * @dataProvider modProvider
      */
-    public function shouldMod(string $expected, string $left, string $right, int $scale): void
+    public function shouldMod(string $expected, ?string $left, ?string $right, int $scale): void
     {
         self::assertSame($expected, BC::mod($left, $right, $scale));
     }
 
+    /**
+     * @test
+     * @dataProvider throwDivByZeroProvider
+     */
+    public function modShouldThrowDivByZero(?string $divisor): void
+    {
+        $this->expectExceptionMessage('Division by zero');
+        $this->expectException(InvalidArgumentException::class);
+        BC::mod('1', $divisor);
+    }
 
     public function mulProvider(): array
     {
         return [
+            [null, null, '0', 0],
+            [null, '1.5', '0', 0],
+            ['1.5', null, '0', 0],
             ['1', '1.5', '1.5', 1],
             ['10', '1.2500', '12.5', 2],
             ['100', '0.29', '29', 0],
@@ -674,7 +719,7 @@ class BCTest extends TestCase
      * @test
      * @dataProvider mulProvider
      */
-    public function shouldMul(string $leftOperand, string $rightOperand, string $expected, ?int $scale): void
+    public function shouldMul(?string $leftOperand, ?string $rightOperand, string $expected, ?int $scale): void
     {
         self::assertSame($expected, BC::mul($leftOperand, $rightOperand, $scale));
     }
@@ -683,6 +728,9 @@ class BCTest extends TestCase
     public function powProvider(): array
     {
         return [
+            ['1', null, null, 0],
+            ['1', '1', null, 0],
+            ['0', null, '1', 0],
             ['256', '2', '8', 0],
             ['74.08', '4.2', '3', 2],
             ['-32', '-2', '5', 4],
@@ -710,7 +758,7 @@ class BCTest extends TestCase
      * @test
      * @dataProvider powProvider
      */
-    public function shouldPow(string $expected, string $left, string $right, ?int $scale = 0): void
+    public function shouldPow(string $expected, ?string $left, ?string $right, ?int $scale = 0): void
     {
         self::assertSame($expected, BC::pow($left, $right, $scale));
     }
@@ -725,6 +773,10 @@ class BCTest extends TestCase
             [
                 '2.3025850929940456840179914546843642076011014886287729760333279009675726096773524802359972050895982985',
                 '10',
+            ],
+            [
+                '-INF',
+                null,
             ],
             [
                 '-INF',
@@ -745,7 +797,7 @@ class BCTest extends TestCase
      * @test
      * @dataProvider logProvider
      */
-    public function shouldLog(string $expected, string $value): void
+    public function shouldLog(string $expected, ?string $value): void
     {
         self::assertSame($expected, BC::log($value));
     }
@@ -767,6 +819,10 @@ class BCTest extends TestCase
             ],
             [
                 '1',
+                null,
+            ],
+            [
+                '1',
                 '0',
             ],
             [
@@ -780,7 +836,7 @@ class BCTest extends TestCase
      * @test
      * @dataProvider expProvider
      */
-    public function shouldExp(string $expected, string $arg): void
+    public function shouldExp(string $expected, ?string $arg): void
     {
         self::assertSame($expected, BC::exp($arg));
     }
@@ -788,6 +844,8 @@ class BCTest extends TestCase
     public function factProvider(): array
     {
         return [
+            ['1', null],
+            ['1', '0'],
             ['1', 'FOO'],
             ['6', '3'],
             ['24', '4'],
@@ -804,7 +862,7 @@ class BCTest extends TestCase
      * @test
      * @dataProvider factProvider
      */
-    public function shouldFact(string $expected, string $fact): void
+    public function shouldFact(string $expected, ?string $fact): void
     {
         self::assertSame($expected, BC::fact($fact));
     }
@@ -845,6 +903,9 @@ class BCTest extends TestCase
     public function powModProvider(): array
     {
         return [
+            ['1', null, null, '7', 0],
+            ['1', '1', null, '7', 0],
+            ['0', null, '1', '7', 0],
             ['4', '5', '2', '7', 0],
             ['4', '5', '2', '7', null],
             ['-4', '-2', '5', '7', 0],
@@ -863,14 +924,26 @@ class BCTest extends TestCase
      * @test
      * @dataProvider powModProvider
      */
-    public function shouldPowMod(string $expected, string $left, string $right, string $modulus, ?int $scale): void
+    public function shouldPowMod(string $expected, ?string $left, ?string $right, ?string $modulus, ?int $scale): void
     {
         self::assertSame($expected, BC::powMod($left, $right, $modulus, $scale));
+    }
+
+    /**
+     * @test
+     * @dataProvider throwDivByZeroProvider
+     */
+    public function powModShouldThrowDivByZero(?string $divisor): void
+    {
+        $this->expectExceptionMessage('Modulus can\'t be zero');
+        $this->expectException(InvalidArgumentException::class);
+        BC::powMod('1', '2', $divisor);
     }
 
     public function sqrtProvider(): array
     {
         return [
+            ['0', null, 0],
             ['3', '9', 0],
             ['3.07', '9.444', 2],
             ['43913234134.28826', '1928372132132819737213', 5],
@@ -882,7 +955,7 @@ class BCTest extends TestCase
      * @test
      * @dataProvider sqrtProvider
      */
-    public function shouldSqrt(string $expected, string $operand, int $scale): void
+    public function shouldSqrt(string $expected, ?string $operand, int $scale): void
     {
         self::assertSame($expected, BC::sqrt($operand, $scale));
     }
@@ -903,6 +976,7 @@ class BCTest extends TestCase
     public function hexdecProvider(): array
     {
         return [
+            ['0', null],
             ['123', '7b'],
             ['1234567890', '499602d2'],
             ['12345678901234567890', 'ab54a98ceb1f0ad2'],
@@ -915,7 +989,7 @@ class BCTest extends TestCase
      * @test
      * @dataProvider hexdecProvider
      */
-    public function shouldHexdec(string $expected, string $operand): void
+    public function shouldHexdec(string $expected, ?string $operand): void
     {
         self::assertSame($expected, BC::hexdec($operand));
     }
@@ -923,6 +997,7 @@ class BCTest extends TestCase
     public function dechexProvider(): array
     {
         return [
+            ['0', null],
             ['7b', '123'],
             ['ffffffff', '4294967295'],
             ['200000000', '8589934592'],
@@ -936,7 +1011,7 @@ class BCTest extends TestCase
      * @test
      * @dataProvider dechexProvider
      */
-    public function shouldDechex(string $expected, string $operand): void
+    public function shouldDechex(string $expected, ?string $operand): void
     {
         self::assertSame($expected, BC::dechex($operand));
     }
@@ -945,7 +1020,7 @@ class BCTest extends TestCase
      * @test
      * @dataProvider shouldBitAddProvider
      */
-    public function shouldBitAdd(string $expected, string $left, string $right): void
+    public function shouldBitAdd(string $expected, ?string $left, ?string $right): void
     {
         self::assertSame($expected, BC::bitAnd($left, $right));
     }
@@ -953,6 +1028,9 @@ class BCTest extends TestCase
     public function shouldBitAddProvider(): array
     {
         return [
+            ['0', null, null],
+            ['0', null, '1'],
+            ['0', '1', null],
             [
                 '2972225677459078825024027220918272',
                 '1000000000865464564564564567867867867800000',
@@ -974,7 +1052,7 @@ class BCTest extends TestCase
      * @test
      * @dataProvider shouldBitOrProvider
      */
-    public function shouldBitOr(string $expected, string $left, string $right): void
+    public function shouldBitOr(string $expected, ?string $left, ?string $right): void
     {
         self::assertSame($expected, BC::bitOr($left, $right));
     }
@@ -982,6 +1060,9 @@ class BCTest extends TestCase
     public function shouldBitOrProvider(): array
     {
         return [
+            ['0', null, null],
+            ['1', null, '1'],
+            ['1', '1', null],
             [
                 '1000000002894027563651942199302519406881728',
                 '1000000000865464564564564567867867867800000',
@@ -1005,7 +1086,7 @@ class BCTest extends TestCase
      * @test
      * @dataProvider shouldBitXorProvider
      */
-    public function shouldBitXor(string $expected, string $left, string $right): void
+    public function shouldBitXor(string $expected, ?string $left, ?string $right): void
     {
         self::assertSame($expected, BC::bitXor($left, $right));
     }
@@ -1013,6 +1094,9 @@ class BCTest extends TestCase
     public function shouldBitXorProvider(): array
     {
         return [
+            ['0', null, null],
+            ['1', null, '1'],
+            ['1', '1', null],
             ['7', '2', '5'],
             ['-8', '3', '-5'],
             ['-6', '-4', '6'],
@@ -1038,16 +1122,6 @@ class BCTest extends TestCase
      * @test
      */
     public function shouldThrowErrorOnNegativeModPowExponent(): void
-    {
-        $this->expectExceptionMessage('Exponent can\'t be negative');
-        $this->expectException(InvalidArgumentException::class);
-        BC::powMod('10000.123', '-1', '2');
-    }
-
-    /**
-     * @test
-     */
-    public function shouldThrowErrorOnZeroModPowModulus(): void
     {
         $this->expectExceptionMessage('Exponent can\'t be negative');
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
Attempts to fix #39 by allowing `null` as input argument of as many functions of the `BC` class as possible.

- I took the liberty to add PHPStan to the development tools (and CI build) to guide me through these changes (hopefully preventing me from adding new errors in there), which I think is a good addition to any open source library anyway. It runs in Travis' `after_script`, which means if it fails the build will still "pass". I'll let you make it stricter if you want it to be.
- I even used the [bleeding edge](https://phpstan.org/blog/what-is-bleeding-edge) PHPStan feature locally, and it passed. I did not commit that though, as it might break CI on new releases unexpectedly.
- I believe Scrutinizer's 2 reported issues can be safely ignored, as they were already reported 9 months ago (only as the type changed from `string` to `string|null`, it thinks they are "new" errors).

@krowinski if you could please review attentively the added providers in the tests to make sure every value make sense (I'm not 100% sure what hexdec should produce with null as input, for example). Thanks! :pray: 

PS: for those that might need to use this before it's merged upstream, you can set your `composer.json` like so : 

```json
{
    "require": {
        "krowinski/bcmath-extended": "dev-allow-null-as-input"
    },
    "repositories": [
        {
            "type": "vcs",
            "url": "https://github.com/gnutix/bcmath-extended.git"
        }
    ]
}
```